### PR TITLE
test[Pest]: Reincluindo RefreshDatabase trait para todos os testes de…

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,9 +13,12 @@
 
 use Illuminate\Contracts\Auth\Authenticatable;
 
-uses(Tests\TestCase::class)->in('Feature');
-
-//uses(Illuminate\Foundation\Testing\RefreshDatabase::class, Tests\TestCase::class)->in('Feature');
+uses(
+    Illuminate\Foundation\Testing\RefreshDatabase::class,
+    Tests\TestCase::class,
+)
+->beforeEach(fn () => $this->seed())
+->in('Feature');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The code proposed here was covered by testing.
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/beerandcodeteam/adoteumdev/tree/dev/docs) or explained in the PR's description.


If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
**Sobre as modificações propostas**
A `trait` RefreshDatabase foi removida dos testes funcionais, devido a um erro que estava ocorrendo nos testes `InterestStoreTest.php` e `KnowledgeStoreTest.php`. Como o comportamento padrão da trait `RefreshDatabase` é de sempre que um teste terminar refazer o banco de dados, ao executar os testes precisaremos popular os dados sempre que formos iniciar um teste.

Existem diversas formas de se aplicar tal funcionalidade, porém como adotamos para os testes do projeto o uso do `PEST`, então decidi aplicar a solução da forma em que a documentação do PEST orienta.

> O mais correto seria aplicarmos os `seed's` apenas nos testes que necessitarem de usar os dados persistidos no banco de dados, porém como teremos **N** testes ainda a serem criados, de modo que possamos agilizar e facilitar as coisas, estarei aplicando a solução de forma `GLOBAL` no PEST. Logo, os dados serão populados no banco de dados através de `seed's` antes que cada teste de funcionalidade seja executado. Posteriormente podemos refatorar essa parte e adequar apenas aos testes que necessitem realmente, caso tenhamos alguma perca de performance, ou sintamos a necessidade. 

Abaixo podemos ver a linha de código no qual iremos substituir.
https://github.com/beerandcodeteam/adoteumdev/blob/e74e5fa69bd3eff2947e8ca2d129c4a300157563/tests/Pest.php#L16

Após o devido ajuste o trecho de código deve ficar a seguinte forma
```php
uses(
    Illuminate\Foundation\Testing\RefreshDatabase::class,
    Tests\TestCase::class,
)
->beforeEach(fn () => $this->seed())
->in('Feature');
```
Após as alterações realizadas, testes executados com sucesso!

![seeds_and_refresh_database_in_tests](https://user-images.githubusercontent.com/2080547/132970018-e2c8f057-aa63-48bf-9a80-9fb04576e7a5.gif)

