### PR TITLE
Fix for form store test in InterestStoreTest and KnowledgeStoreTest

### DIFF
--- a/tests/Feature/InterestStoreTest.php
+++ b/tests/Feature/InterestStoreTest.php
@@ -21,25 +21,24 @@ it('checks if interests list was loaded', function () {
         ->assertSee("Assembly");
 });
 
-it('checks if interests form was stored successful', function () {
+it('stores interests form', function () {
     $payload = [
-        ['skill_id' => 1, 'level' => 3, 'category_id' => 1],
-        ['skill_id' => 2, 'level' => 4, 'category_id' => 1],
-        ['skill_id' => 3, 'level' => 1, 'category_id' => 1],
-        ['skill_id' => 4, 'level' => 5, 'category_id' => 1],
+        ['id' => 1, 'level' => 3, 'category_id' => 1],
+        ['id' => 2, 'level' => 4, 'category_id' => 1],
+        ['id' => 3, 'level' => 1, 'category_id' => 1],
+        ['id' => 4, 'level' => 5, 'category_id' => 1],
     ];
 
     $user = User::firstWhere('email', '33piter@adoteum.dev');
 
+    $this->assertDatabaseMissing('interests', ['user_id' => $user->id]);
+
     actingAs($user->load('profile'));
 
-    $test = livewire(InterestScreen::class)
+    livewire(InterestScreen::class)
         ->set('payload', $payload)
-        ->call('save');
+        ->call('save')
+        ->assertRedirect(route('app.knowledge'));
 
-    assertDatabaseHas('interests', [
-        'user_id' => $user->id,
-    ]);
-
-    $test->assertRedirect(route('app.knowledge'));
+    $this->assertDatabaseHas('interests', ['user_id' => $user->id]);
 });

--- a/tests/Feature/KnowledgeStoreTest.php
+++ b/tests/Feature/KnowledgeStoreTest.php
@@ -31,15 +31,14 @@ it('stores knowledge form', function () {
 
     $user = User::firstWhere('email', '33piter@adoteum.dev');
 
+    $this->assertDatabaseMissing('knowledge', ['user_id' => $user->id]);
+
     actingAs($user->load('profile'));
 
-    $test = livewire(KnowledgeScreen::class)
+    livewire(KnowledgeScreen::class)
         ->set('payload', $payload)
-        ->call('save');
+        ->call('save')
+        ->assertRedirect(route('app.developers'));
 
-    assertDatabaseHas('knowledge', [
-        'user_id' => $user->id,
-    ]);
-
-    $test->assertRedirect(route('app.developers'));
+    $this->assertDatabaseHas('knowledge', ['user_id' => $user->id]);
 });

--- a/tests/Feature/KnowledgeStoreTest.php
+++ b/tests/Feature/KnowledgeStoreTest.php
@@ -23,10 +23,10 @@ it('checks if knowledge list was loaded', function () {
 
 it('checks if knowledge form was stored successful', function () {
     $payload = [
-        ['skill_id' => 1, 'level' => 3, 'category_id' => 1],
-        ['skill_id' => 2, 'level' => 4, 'category_id' => 1],
-        ['skill_id' => 3, 'level' => 1, 'category_id' => 1],
-        ['skill_id' => 4, 'level' => 5, 'category_id' => 1],
+        ['id' => 1, 'level' => 3, 'category_id' => 1],
+        ['id' => 2, 'level' => 4, 'category_id' => 1],
+        ['id' => 3, 'level' => 1, 'category_id' => 1],
+        ['id' => 4, 'level' => 5, 'category_id' => 1],
     ];
 
     $user = User::firstWhere('email', '33piter@adoteum.dev');

--- a/tests/Feature/KnowledgeStoreTest.php
+++ b/tests/Feature/KnowledgeStoreTest.php
@@ -21,7 +21,7 @@ it('checks if knowledge list was loaded', function () {
         ->assertSee("Assembly");
 });
 
-it('checks if knowledge form was stored successful', function () {
+it('stores knowledge form', function () {
     $payload = [
         ['id' => 1, 'level' => 3, 'category_id' => 1],
         ['id' => 2, 'level' => 4, 'category_id' => 1],

--- a/tests/Feature/KnowledgeStoreTest.php
+++ b/tests/Feature/KnowledgeStoreTest.php
@@ -13,7 +13,7 @@ it('checks if knowledge url is working', function () {
         ->assertOk();
 });
 
-it('checks if knoledge list was loaded', function () {
+it('checks if knowledge list was loaded', function () {
     $user = User::firstWhere('email', '33piter@adoteum.dev');
 
     actingAs($user->load('profile'))


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The code proposed here was covered by testing.
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/beerandcodeteam/adoteumdev/tree/dev/docs) or explained in the PR's description.


If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Hi folks,

Tests are failing because the code below expects 'id' and test payload sends 'skill_id'. 

```php
            Interest::query()->updateOrCreate([
                'user_id' => auth()->user()->id,
                'skill_id' => $skill['id'],
            ],[
                'level' => $skill['level'],
            ]);
```

Test:

```php
//...
$payload = [
        ['skill_id' => 1, 'level' => 3, 'category_id' => 1],
        ['skill_id' => 2, 'level' => 4, 'category_id' => 1],
        ['skill_id' => 3, 'level' => 1, 'category_id' => 1],
        ['skill_id' => 4, 'level' => 5, 'category_id' => 1],
    ];
```

I have changed the tests accordingly and re-styled a bit.

Also, is `category_id` needed in the payload?

Greetings and thanks,

Dan