### PR TITLE
including pipeline to run tests on pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   ci:
+    if: startsWith(github.head_ref, 'dependabot') == false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -22,11 +23,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-      if: startsWith(github.head_ref, 'dependabot') == false
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
-      if: startsWith(github.head_ref, 'dependabot') == false
       with:
         php-version: ${{ matrix.php }}
         extensions: mbstring, dom, fileinfo, mysql
@@ -34,15 +33,12 @@ jobs:
         coverage: none
 
     - name: Install PHP dependencies
-      if: startsWith(github.head_ref, 'dependabot') == false
       run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
 
     - name: Setup Laravel
-      if: startsWith(github.head_ref, 'dependabot') == false
       run: |
         cp .env.example .env
         php artisan key:generate
 
     - name: Running tests
-      if: startsWith(github.head_ref, 'dependabot') == false
       run: vendor/bin/pest ${{ matrix.parallel }} --colors=always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: Tests
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.gitignore'
+      - '**.prettierrc'
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        php: ['8.0','8.1']
+        dependency-version: [prefer-stable]
+        parallel: ['--parallel']
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }} - ${{ matrix.parallel }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      if: startsWith(github.head_ref, 'dependabot') == false
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      if: startsWith(github.head_ref, 'dependabot') == false
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: mbstring, dom, fileinfo, mysql
+        tools: composer:v2
+        coverage: none
+
+    - name: Install PHP dependencies
+      if: startsWith(github.head_ref, 'dependabot') == false
+      run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
+
+    - name: Setup Laravel
+      if: startsWith(github.head_ref, 'dependabot') == false
+      run: |
+        cp .env.example .env
+        php artisan key:generate
+
+    - name: Running tests
+      if: startsWith(github.head_ref, 'dependabot') == false
+      run: vendor/bin/pest ${{ matrix.parallel }} --colors=always


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

This implementation introduces a github workflow to run tests as _checks_. When someone opens a PR, an action will run the tests and reviewers will be able to see if they are passing as a checklist. The in-action tests will run for PHP 8.0 and 8.1. PRs related to updating dependencies (a.k.a. dependabot) will not execute the action.


**Note:**
If a test was written using an external connection, you'll need to add the access info as project secrets and make sure to load them before running the test. That's why I recommend use test doubles when testing an external service, because in this way, your tests will not have external dependencies.
