### PR TITLE
fixes healthy check on docker-compose of meilisearch service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
         networks:
             - sail
         healthcheck:
-          test: ["CMD", "wget", "--no-verbose", "--spider",  "http://localhost:7700/health"]
+          test: ["CMD", "wget", "--no-verbose", "--spider",  "http://${MEILI_HTTP_ADDR:-localhost:7700}/health"]
           retries: 3
           timeout: 5s
     mailhog:


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The code proposed here was covered by testing.
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/beerandcodeteam/adoteumdev/tree/dev/docs) or explained in the PR's description.


If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When I added new environment variables to the meilisearch service, due to lack of attention I forgot to change the URL used to check if the container is healthy. Here is the small correction.

```yaml
...
healthcheck:
   test: ["CMD", "wget", "--no-verbose", "--spider",  "http://${MEILI_HTTP_ADDR:-localhost:7700}/health"]
   retries: 3
   timeout: 5s
```
> `MEILI_HTTP_ADDR` must be defined in your .env file

This way the service will always use the settings in the `.env` file, no longer setting the url of the meilisearch service to `localhost:7700/health`, giving us the correct container health information either by console or using some container orchestrator.

**in console**
![console](https://user-images.githubusercontent.com/2080547/139594593-78ebaf25-e247-436c-97b5-a35c8ea2f0bb.png)

**in orchestrator**
![orchestrator](https://user-images.githubusercontent.com/2080547/139594598-978b558b-b474-4248-a378-7dee24d6d864.png)

