### PR TITLE
fix for checking existence of `sonar-project.properties` configuratio…

### DIFF
--- a/sail
+++ b/sail
@@ -53,6 +53,7 @@ configureSail() {
     echo -e "${LABEL_ADOTE}is starting to download packages and self-configure."
 
     ENVFILE='./.env'
+    SONARFILE='sonar-project.properties'
 
     docker run --rm \
         -u "$(id -u):$(id -g)" \
@@ -72,7 +73,7 @@ configureSail() {
         cp .env.example .env
     fi
 
-    if [ ! -f './.sonar.example' ]; then
+    if [ ! -f $SONARFILE ]; then
         cp .sonar.example sonar-project.properties
     fi
 


### PR DESCRIPTION
…n file in sail script configureSail function

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The code proposed here was covered by testing.
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/beerandcodeteam/adoteumdev/tree/dev/docs) or explained in the PR's description.


If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Small correction, in the `sail` script. Correcting existence check of file containing project settings (`sonar-project.properties`) for the **sonarqube** service.

**before**
```bash
if [ ! -f './.sonar.example' ]; then
    cp .sonar.example sonar-project.properties
fi
```

**after**
```bash
SONARFILE='sonar-project.properties'
...
if [ ! -f $SONARFILE ]; then
    cp .sonar.example sonar-project.properties
fi
```